### PR TITLE
Resolver dependency injection

### DIFF
--- a/src/main/java/com/ddoerr/scriptit/ScriptItMod.java
+++ b/src/main/java/com/ddoerr/scriptit/ScriptItMod.java
@@ -92,7 +92,7 @@ public class ScriptItMod implements ClientModInitializer {
 
 			ClientTickCallback.EVENT.register(mc -> {
 				if (openGuiKeyBinding.wasPressed()) {
-					history.open(ScriptOverviewScreen::new);
+					history.open(ScriptOverviewScreen.class);
 				}
 
 				if (mc.player != null) {

--- a/src/main/java/com/ddoerr/scriptit/ScriptItMod.java
+++ b/src/main/java/com/ddoerr/scriptit/ScriptItMod.java
@@ -40,19 +40,23 @@ public class ScriptItMod implements ClientModInitializer {
 	public void onInitializeClient() {
 		Resolver resolver = Resolver.getInstance();
 
-		resolver.add(MinecraftClient.getInstance());
-		resolver.add(new ScreenHistory());
-		resolver.add(new EventBus());
-		resolver.add(new KeyBindingBusExtension());
-		resolver.add(new ThreadLifetimeManagerImpl());
-		resolver.add(new LibraryLoaderImpl());
-		resolver.add(new LanguageLoaderImpl());
-		resolver.add(new HudElementLoaderImpl());
-		resolver.add(new HudElementManagerImpl());
-		resolver.add(new EventLoaderImpl());
-		resolver.add(new ScriptManagerImpl());
+		try {
+			resolver.add(MinecraftClient.getInstance());
+			resolver.add(ScreenHistory.class);
+			resolver.add(new EventBus());
+			resolver.add(KeyBindingBusExtension.class);
+			resolver.add(new ThreadLifetimeManagerImpl());
+			resolver.add(new LibraryLoaderImpl());
+			resolver.add(new LanguageLoaderImpl());
+			resolver.add(new HudElementLoaderImpl());
+			resolver.add(new HudElementManagerImpl());
+			resolver.add(new EventLoaderImpl());
+			resolver.add(new ScriptManagerImpl());
 
-		resolver.add(new ConfigHandler());
+			resolver.add(ConfigHandler.class);
+		} catch (DependencyException e) {
+			e.printStackTrace();
+		}
 
 		FabricKeyBinding openGuiKeyBinding = FabricKeyBinding.Builder.create(
 				new Identifier(MOD_NAME, "open"),

--- a/src/main/java/com/ddoerr/scriptit/api/bus/KeyBindingBusExtension.java
+++ b/src/main/java/com/ddoerr/scriptit/api/bus/KeyBindingBusExtension.java
@@ -1,8 +1,6 @@
 package com.ddoerr.scriptit.api.bus;
 
 import com.ddoerr.scriptit.ScriptItMod;
-import com.ddoerr.scriptit.api.dependencies.Resolver;
-import com.ddoerr.scriptit.api.exceptions.DependencyException;
 import com.ddoerr.scriptit.api.util.KeyBindingHelper;
 import net.minecraft.client.options.KeyBinding;
 import net.minecraft.client.util.InputUtil;
@@ -17,14 +15,10 @@ public class KeyBindingBusExtension implements Tickable{
     EventBus eventBus;
     Map<String, KeyBinding> keyBindings = new HashMap<>();
 
-    public KeyBindingBusExtension() {
-        try {
-            eventBus = Resolver.getInstance().resolve(EventBus.class);
-            eventBus.subscribe("bus:added", this::newEvent);
-            eventBus.subscribe("bus:removed", this::removedEvent);
-        } catch (DependencyException e) {
-            e.printStackTrace();
-        }
+    public KeyBindingBusExtension(EventBus eventBus) {
+        eventBus.subscribe("bus:added", this::newEvent);
+        eventBus.subscribe("bus:removed", this::removedEvent);
+        this.eventBus = eventBus;
     }
 
     private void newEvent(Object idObject) {

--- a/src/main/java/com/ddoerr/scriptit/api/dependencies/Resolver.java
+++ b/src/main/java/com/ddoerr/scriptit/api/dependencies/Resolver.java
@@ -10,9 +10,10 @@ public interface Resolver {
     }
 
     <T> void add(T dependency);
+    <T> void add(Class<T> dependencyClass) throws DependencyException;
 
     <T> T resolve(Class<T> dependencyClass) throws DependencyException;
     <T> List<T> resolveAll(Class<T> dependencyClass);
 
-    <T> T create(Class<T> type) throws DependencyException;
+    <T> T create(Class<T> type, Object... parameters) throws DependencyException;
 }

--- a/src/main/java/com/ddoerr/scriptit/config/ConfigHandler.java
+++ b/src/main/java/com/ddoerr/scriptit/config/ConfigHandler.java
@@ -19,13 +19,9 @@ public class ConfigHandler implements ConfigCallback, Loadable {
     private ScriptManager scriptManager;
     private HudElementManager hudElementManager;
 
-    public ConfigHandler() {
-        try {
-            scriptManager = Resolver.getInstance().resolve(ScriptManager.class);
-            hudElementManager = Resolver.getInstance().resolve(HudElementManager.class);
-        } catch (DependencyException e) {
-            e.printStackTrace();
-        }
+    public ConfigHandler(ScriptManager scriptManager, HudElementManager hudElementManager) {
+        this.scriptManager = scriptManager;
+        this.hudElementManager = hudElementManager;
     }
 
     public void save() {

--- a/src/main/java/com/ddoerr/scriptit/screens/AbstractHistoryScreen.java
+++ b/src/main/java/com/ddoerr/scriptit/screens/AbstractHistoryScreen.java
@@ -6,17 +6,11 @@ import net.minecraft.client.gui.screen.Screen;
 import org.lwjgl.glfw.GLFW;
 import spinnery.client.BaseScreen;
 
-import java.util.function.Supplier;
-
 public class AbstractHistoryScreen extends BaseScreen {
     private ScreenHistory history;
 
-    public AbstractHistoryScreen() {
-        try {
-            history = Resolver.getInstance().resolve(ScreenHistory.class);
-        } catch (DependencyException e) {
-            e.printStackTrace();
-        }
+    public AbstractHistoryScreen(ScreenHistory history) {
+        this.history = history;
     }
 
     @Override
@@ -24,8 +18,8 @@ public class AbstractHistoryScreen extends BaseScreen {
         history.back();
     }
 
-    protected void openScreen(Supplier<Screen> screenSupplier) {
-        history.open(screenSupplier);
+    protected void openScreen(Class<? extends Screen> screenClass, Object... parameters) {
+        history.open(screenClass, parameters);
     }
 
     @Override

--- a/src/main/java/com/ddoerr/scriptit/screens/HudElementEditorScreen.java
+++ b/src/main/java/com/ddoerr/scriptit/screens/HudElementEditorScreen.java
@@ -1,6 +1,7 @@
 package com.ddoerr.scriptit.screens;
 
 import com.ddoerr.scriptit.ScriptItMod;
+import com.ddoerr.scriptit.api.dependencies.Resolver;
 import com.ddoerr.scriptit.api.hud.HudHorizontalAnchor;
 import com.ddoerr.scriptit.api.hud.HudVerticalAnchor;
 import com.ddoerr.scriptit.api.util.geometry.Point;
@@ -22,8 +23,8 @@ public class HudElementEditorScreen extends AbstractHistoryScreen {
     HudHorizontalAnchor horizontalAnchor;
     HudVerticalAnchor verticalAnchor;
 
-    public HudElementEditorScreen(HudElement hudElement) {
-        super();
+    public HudElementEditorScreen(ScreenHistory history, HudElement hudElement) {
+        super(history);
 
         this.hudElement = hudElement;
 
@@ -41,7 +42,7 @@ public class HudElementEditorScreen extends AbstractHistoryScreen {
 
         panel.createChild(WButton.class, Position.of(panel, 10, 10), Size.of(180, 20))
                 .setOnMouseClicked((widget, mouseX, mouseY, mouseButton) -> {
-                    openScreen(() -> new ScriptEditorScreen(hudElement.getScriptContainer()));
+                    openScreen(ScriptEditorScreen.class, hudElement.getScriptContainer());
                 })
                 .setLabel(new TranslatableText(new Identifier(ScriptItMod.MOD_NAME, "elements.edit.script").toString()));
 

--- a/src/main/java/com/ddoerr/scriptit/screens/HudElementOverviewScreen.java
+++ b/src/main/java/com/ddoerr/scriptit/screens/HudElementOverviewScreen.java
@@ -3,7 +3,6 @@ package com.ddoerr.scriptit.screens;
 import com.ddoerr.scriptit.ScriptItMod;
 import com.ddoerr.scriptit.api.dependencies.HudElementLoader;
 import com.ddoerr.scriptit.api.dependencies.Resolver;
-import com.ddoerr.scriptit.api.exceptions.DependencyException;
 import com.ddoerr.scriptit.api.hud.HudElementManager;
 import com.ddoerr.scriptit.api.hud.HudElementProvider;
 import com.ddoerr.scriptit.api.util.Color;
@@ -52,19 +51,15 @@ public class HudElementOverviewScreen extends AbstractHistoryScreen {
 
     ValuesDropdownWidget<String> dropdown;
 
-    public HudElementOverviewScreen() {
-        super();
+    public HudElementOverviewScreen(ScreenHistory history, HudElementManager hudElementManager, HudElementLoader hudElementLoader) {
+        super(history);
 
-        try {
-            hudElementManager = Resolver.getInstance().resolve(HudElementManager.class);
-            hudElementLoader = Resolver.getInstance().resolve(HudElementLoader.class);
+        this.hudElementManager = hudElementManager;
+        this.hudElementLoader = hudElementLoader;
 
-            hudElements = hudElementManager.getAll();
+        this.hudElements = hudElementManager.getAll();
 
-            setupWidgets();
-        } catch (DependencyException e) {
-            e.printStackTrace();
-        }
+        setupWidgets();
     }
 
     @Override
@@ -121,7 +116,7 @@ public class HudElementOverviewScreen extends AbstractHistoryScreen {
             Duration duration = Duration.between(lastTimeClicked, timeClicked);
 
             if (duration.compareTo(durationBetweenClicks) < 0) {
-                openScreen(() -> new HudElementEditorScreen(focusedHudElement));
+                openScreen(HudElementEditorScreen.class, focusedHudElement);
             }
         }
 

--- a/src/main/java/com/ddoerr/scriptit/screens/ScriptEditorScreen.java
+++ b/src/main/java/com/ddoerr/scriptit/screens/ScriptEditorScreen.java
@@ -4,7 +4,6 @@ import com.ddoerr.scriptit.ScriptItMod;
 import com.ddoerr.scriptit.api.bus.KeyBindingBusExtension;
 import com.ddoerr.scriptit.api.dependencies.EventLoader;
 import com.ddoerr.scriptit.api.dependencies.Resolver;
-import com.ddoerr.scriptit.api.exceptions.DependencyException;
 import com.ddoerr.scriptit.api.scripts.LifeCycle;
 import com.ddoerr.scriptit.api.scripts.ScriptManager;
 import com.ddoerr.scriptit.api.util.DurationHelper;
@@ -48,32 +47,20 @@ public class ScriptEditorScreen extends AbstractHistoryScreen {
     private EventLoader eventLoader;
     private ScriptManager scriptManager;
 
-    public ScriptEditorScreen() {
-        super();
+    public ScriptEditorScreen(ScreenHistory history, Resolver resolver, EventLoader eventLoader, ScriptManager scriptManager) {
+        super(history);
 
-        Resolver resolver = Resolver.getInstance();
-
-        try {
-            eventLoader = resolver.resolve(EventLoader.class);
-            scriptManager = resolver.resolve(ScriptManager.class);
-        } catch (DependencyException e) {
-            e.printStackTrace();
-        }
+        this.eventLoader = eventLoader;
+        this.scriptManager = scriptManager;
 
         setupWidgets();
     }
 
-    public ScriptEditorScreen(ScriptContainer scriptContainer) {
-        super();
+    public ScriptEditorScreen(ScreenHistory history, EventLoader eventLoader, ScriptManager scriptManager, ScriptContainer scriptContainer) {
+        super(history);
 
-        Resolver resolver = Resolver.getInstance();
-        try {
-            eventLoader = resolver.resolve(EventLoader.class);
-            scriptManager = resolver.resolve(ScriptManager.class);
-        } catch (DependencyException e) {
-            e.printStackTrace();
-        }
-
+        this.eventLoader = eventLoader;
+        this.scriptManager = scriptManager;
         this.scriptContainer = scriptContainer;
 
         lifeCycle = scriptContainer.getLifeCycle();

--- a/src/main/java/com/ddoerr/scriptit/screens/ScriptEditorScreen.java
+++ b/src/main/java/com/ddoerr/scriptit/screens/ScriptEditorScreen.java
@@ -47,7 +47,7 @@ public class ScriptEditorScreen extends AbstractHistoryScreen {
     private EventLoader eventLoader;
     private ScriptManager scriptManager;
 
-    public ScriptEditorScreen(ScreenHistory history, Resolver resolver, EventLoader eventLoader, ScriptManager scriptManager) {
+    public ScriptEditorScreen(ScreenHistory history, EventLoader eventLoader, ScriptManager scriptManager) {
         super(history);
 
         this.eventLoader = eventLoader;

--- a/src/main/java/com/ddoerr/scriptit/screens/ScriptOverviewScreen.java
+++ b/src/main/java/com/ddoerr/scriptit/screens/ScriptOverviewScreen.java
@@ -2,7 +2,6 @@ package com.ddoerr.scriptit.screens;
 
 import com.ddoerr.scriptit.ScriptItMod;
 import com.ddoerr.scriptit.api.dependencies.Resolver;
-import com.ddoerr.scriptit.api.exceptions.DependencyException;
 import com.ddoerr.scriptit.api.scripts.ScriptManager;
 import com.ddoerr.scriptit.callbacks.ConfigCallback;
 import com.ddoerr.scriptit.screens.widgets.PanelWidget;
@@ -18,16 +17,12 @@ import spinnery.widget.api.Size;
 public class ScriptOverviewScreen extends AbstractHistoryScreen {
     private ScriptManager scriptManager;
 
-    public ScriptOverviewScreen() {
-        super();
+    public ScriptOverviewScreen(ScreenHistory history, ScriptManager scriptManager, MinecraftClient minecraft) {
+        super(history);
 
-        try {
-            scriptManager = Resolver.getInstance().resolve(ScriptManager.class);
-        } catch (DependencyException e) {
-            e.printStackTrace();
-        }
+        this.scriptManager = scriptManager;
+        this.minecraft = minecraft;
 
-        minecraft = MinecraftClient.getInstance();
         setupWidgets();
     }
 
@@ -73,7 +68,7 @@ public class ScriptOverviewScreen extends AbstractHistoryScreen {
         row.createChild(WButton.class)
                 .setSize(Size.of(80, 20))
                 .setLabel(new TranslatableText(new Identifier(ScriptItMod.MOD_NAME, "scripts.edit").toString()))
-                .setOnMouseClicked((widget, mouseX, mouseY, delta) -> openScreen(() -> new ScriptEditorScreen(scriptContainer)))
+                .setOnMouseClicked((widget, mouseX, mouseY, delta) -> openScreen(ScriptEditorScreen.class, scriptContainer))
                 .setOnAlign(w -> w.setPosition(Position.ofTopRight(row).add(-175, 0, 0)));
 
         row.createChild(WButton.class)
@@ -101,7 +96,7 @@ public class ScriptOverviewScreen extends AbstractHistoryScreen {
                 .setSize(Size.of(100, 20))
                 .setOnAlign(w -> w.setPosition(Position.of(panel, 4, 4)))
                 .setLabel(new TranslatableText(new Identifier(ScriptItMod.MOD_NAME, "scripts.add").toString()))
-                .setOnMouseClicked((widget, mouseX, mouseY, delta) -> openScreen(ScriptEditorScreen::new));
+                .setOnMouseClicked((widget, mouseX, mouseY, delta) -> openScreen(ScriptEditorScreen.class));
     }
 
     private void setupOpenDesignerButton(WInterface mainInterface) {
@@ -113,6 +108,6 @@ public class ScriptOverviewScreen extends AbstractHistoryScreen {
                 .setSize(Size.of(100, 20))
                 .setOnAlign(w -> w.setPosition(Position.of(panel, 4, 4)))
                 .setLabel(new TranslatableText(new Identifier(ScriptItMod.MOD_NAME, "elements.open").toString()))
-                .setOnMouseClicked((widget, mouseX, mouseY, delta) -> openScreen(HudElementOverviewScreen::new));
+                .setOnMouseClicked((widget, mouseX, mouseY, delta) -> openScreen(HudElementOverviewScreen.class));
     }
 }


### PR DESCRIPTION
There are still some places where classes directly access `Resolver.getInstance`, but this pr at least removes the easy to fix accesses.